### PR TITLE
Add Firmware, direct links generator & GSI help on start

### DIFF
--- a/handlers/callbackQuery.js
+++ b/handlers/callbackQuery.js
@@ -103,6 +103,11 @@ class CallbacksController extends TelegramBaseCallbackQueryController {
                         text: "GSI",
                         callback_data: "help|gsi"
                         }]);
+                kb.inline_keyboard.push(
+                        [{
+                        text: "Direct Link Generator",
+                        callback_data: "help|directlinks"
+                        }]);
                 msg = "Commands List"
 
                 break;
@@ -222,6 +227,16 @@ class CallbacksController extends TelegramBaseCallbackQueryController {
                 msg = "Search for Generic System Images\n\n"
                 msg += "Usage: /gsi ( Tap command for more info )\n"
                 break;
+
+           case "directlinks":
+                msg = "Generate direct links for different sources\n\n"
+                msg += "Usage: Paste downloadable links from supported source\n\n"
+                msg += "Currently Supported:\n\n"
+                msg += "`Google Drive\n`"
+                msg += "`Mega\n`"
+                msg += "`Android File Host a.k.a AFH\n`"
+                msg += "`Sourceforge\n`"
+                msg += "`Github Releases`"
         }
 
         if (params[1] !== "main") {

--- a/handlers/callbackQuery.js
+++ b/handlers/callbackQuery.js
@@ -99,6 +99,9 @@ class CallbacksController extends TelegramBaseCallbackQueryController {
                         [{
                         text: "Firmwares",
                         callback_data: "help|firmware"
+                        }, {
+                        text: "GSI",
+                        callback_data: "help|gsi"
                         }]);
                 msg = "Commands List"
 
@@ -213,6 +216,11 @@ class CallbacksController extends TelegramBaseCallbackQueryController {
                 msg += "/xiaomi ( Xiaomi )\n"
                 msg += "/asus ( Asus )\n"
                 msg += "/huawei ( Huawei )\n"
+                break;
+
+            case "gsi":
+                msg = "Search for Generic System Images\n\n"
+                msg += "Usage: /gsi ( Tap command for more info )\n"
                 break;
         }
 

--- a/handlers/callbackQuery.js
+++ b/handlers/callbackQuery.js
@@ -95,6 +95,11 @@ class CallbacksController extends TelegramBaseCallbackQueryController {
                         text: "microG",
                         callback_data: "help|microg"
                         }]);
+                kb.inline_keyboard.push(
+                        [{
+                        text: "Firmwares",
+                        callback_data: "help|firmware"
+                        }]);
                 msg = "Commands List"
 
                 break;
@@ -196,6 +201,18 @@ class CallbacksController extends TelegramBaseCallbackQueryController {
 
             case "microg":
                 msg = "/microg | Get latests microG packages"
+                break;
+
+            case "firmware":
+                msg = "Search for OFFICIAL OEM firmwares\n\n"
+                msg += "Usage: /oemname devicecodename ( Ex: /moto harpia )\n"
+                msg += "Tap a specific command for more help\n\n"
+                msg += "Supported OEMs/commands \n"
+                msg += "/moto ( Motorola )\n"
+                msg += "/op ( Oneplus )\n"
+                msg += "/xiaomi ( Xiaomi )\n"
+                msg += "/asus ( Asus )\n"
+                msg += "/huawei ( Huawei )\n"
                 break;
         }
 

--- a/handlers/start.js
+++ b/handlers/start.js
@@ -65,6 +65,9 @@ class StartController extends TelegramBaseController {
                         [{
                 text: "Firmwares",
                 callback_data: "help|firmware"
+                        }, {
+                text: "GSI",
+                callback_data: "help|gsi"
                         }]);
         if ($.message.from.id == $.message.chat.id) {
             tg.api.sendMessage($.message.from.id, "Menu", {

--- a/handlers/start.js
+++ b/handlers/start.js
@@ -61,6 +61,11 @@ class StartController extends TelegramBaseController {
                 text: "microG",
                 callback_data: "help|microg"
                         }]);
+        kb.inline_keyboard.push(
+                        [{
+                text: "Firmwares",
+                callback_data: "help|firmware"
+                        }]);
         if ($.message.from.id == $.message.chat.id) {
             tg.api.sendMessage($.message.from.id, "Menu", {
                 parse_mode: "markdown",

--- a/handlers/start.js
+++ b/handlers/start.js
@@ -69,6 +69,11 @@ class StartController extends TelegramBaseController {
                 text: "GSI",
                 callback_data: "help|gsi"
                         }]);
+        kb.inline_keyboard.push(
+                        [{
+                text: "Direct Link Generator",
+                callback_data: "help|directlinks"
+                        }]);
         if ($.message.from.id == $.message.chat.id) {
             tg.api.sendMessage($.message.from.id, "Menu", {
                 parse_mode: "markdown",


### PR DESCRIPTION
Output:

    Search for OFFICIAL OEM firmwares

    Usage: /oemname devicecodename ( Ex: /moto harpia )
    Tap a specific command for more help

    Supported OEMs/commands
    /moto ( Motorola )
    /op ( Oneplus )
    /xiaomi ( Xiaomi )
    /asus ( Asus )
    /huawei ( Huawei )