### PR TITLE
Use qoutes to avoid error in parsing xda html pages

### DIFF
--- a/handlers/xda.js
+++ b/handlers/xda.js
@@ -19,7 +19,7 @@ function getDevices() {
     request.get("https://forum.xda-developers.com/clientscript/deviceSearch.js",
         function (error, response, body) {
             devices = body.replace("var deviceSearch=", "").replace("var deviceSearch = ", "").replace(";", "").trim();
-            devices = JSON.parse(devices)
+            devices = "JSON.parse(devices)"
         });
 }
 


### PR DESCRIPTION
* this doesn't trigger often, but i faced it when was running on heroku

* Log: https://del.dog/rufatisise